### PR TITLE
Use abs instead of fabs in psnrhvsm code

### DIFF
--- a/tests/psnrhvsm/psnrhvs.c
+++ b/tests/psnrhvsm/psnrhvs.c
@@ -259,7 +259,7 @@ static double calc_psnrhvs(const unsigned char *_src,int _systride,
       for(i=0;i<8;i++){
         for(j=0;j<8;j++){
           float err;
-          err=fabs(dct_s[i*8+j]-dct_d[i*8+j]);
+          err=abs(dct_s[i*8+j]-dct_d[i*8+j]);
           if(i!=0||j!=0)err=err<s_mask/mask[i][j]?0:err-s_mask/mask[i][j];
           ret+=(err*_csf[i][j])*(err*_csf[i][j]);
           pixels++;


### PR DESCRIPTION
Fix for this:

```
Compiling psnrhvsm...
psnrhvs.c:262:15: warning: using floating point absolute value function 'fabs' when argument is of integer type
      [-Wabsolute-value]
          err=fabs(dct_s[i*8+j]-dct_d[i*8+j]);
              ^
psnrhvs.c:262:15: note: use function 'abs' instead
          err=fabs(dct_s[i*8+j]-dct_d[i*8+j]);
              ^~~~
              abs
```
